### PR TITLE
REFACTOR: 거래내역 DataGrid 셀 수정

### DIFF
--- a/src/components/oasisbot/TransactionHistory.tsx
+++ b/src/components/oasisbot/TransactionHistory.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { Box, Chip, Typography } from "@mui/material";
+import { amber, purple } from "@mui/material/colors";
 import {
   DataGrid,
   GridCellParams,
   GridColDef,
+  GridTreeNode,
+  GridValidRowModel,
   GridValueFormatterParams,
 } from "@mui/x-data-grid";
-import { amber, purple } from "@mui/material/colors";
 
 function TransactionHistory() {
   const columns: GridColDef[] = [
@@ -24,7 +26,9 @@ function TransactionHistory() {
       width: 150,
       headerAlign: "center",
       align: "center",
-      renderCell: (params: GridCellParams) => (
+      renderCell: (
+        params: GridCellParams<GridValidRowModel, string, string, GridTreeNode>,
+      ) => (
         <Chip
           label={params.value}
           sx={{
@@ -45,7 +49,9 @@ function TransactionHistory() {
       align: "center",
       valueFormatter: (params: GridValueFormatterParams<number>) =>
         params.value ? `${params.value.toLocaleString()} KRW` : "-",
-      renderCell: (params: GridCellParams) => (
+      renderCell: (
+        params: GridCellParams<GridValidRowModel, number, string, GridTreeNode>,
+      ) => (
         <Typography variant="body2" component="span">
           {params.formattedValue}
         </Typography>
@@ -66,7 +72,9 @@ function TransactionHistory() {
       align: "center",
       valueFormatter: (params: GridValueFormatterParams<number>) =>
         params.value ? `${params.value.toLocaleString()} KRW` : "-",
-      renderCell: (params: GridCellParams) => (
+      renderCell: (
+        params: GridCellParams<GridValidRowModel, number, string, GridTreeNode>,
+      ) => (
         <Typography variant="body2" component="span">
           {params.formattedValue}
         </Typography>
@@ -78,15 +86,23 @@ function TransactionHistory() {
       width: 220,
       headerAlign: "center",
       align: "center",
-      renderCell: (params: GridCellParams) => (
-        <Typography
-          variant="body2"
-          component="span"
-          color={params.value.slice(0, 1) === "-" ? "blue" : "red"}
-        >
-          {params.value}
-        </Typography>
-      ),
+      valueFormatter: (params: GridValueFormatterParams<string>) => {
+        if (!params.value) return "-";
+        return params.value;
+      },
+      renderCell: (
+        params: GridCellParams<GridValidRowModel, string, string, GridTreeNode>,
+      ) => {
+        return (
+          <Typography
+            variant="body2"
+            component="span"
+            color={params.formattedValue?.slice(0, 1) === "-" ? "blue" : "red"}
+          >
+            {params.formattedValue}
+          </Typography>
+        );
+      },
     },
     {
       field: "realizedProfit",
@@ -96,7 +112,9 @@ function TransactionHistory() {
       align: "center",
       valueFormatter: (params: GridValueFormatterParams<number>) =>
         params.value ? `${params.value.toLocaleString()} KRW` : "-",
-      renderCell: (params: GridCellParams) => (
+      renderCell: (
+        params: GridCellParams<GridValidRowModel, number, string, GridTreeNode>,
+      ) => (
         <Typography variant="body2" component="span">
           {params.formattedValue}
         </Typography>

--- a/src/components/oasisbot/TransactionHistory.tsx
+++ b/src/components/oasisbot/TransactionHistory.tsx
@@ -1,17 +1,96 @@
 import React from "react";
-import { Box } from "@mui/material";
-import { DataGrid, GridColDef } from "@mui/x-data-grid";
+import { Box, Chip, Typography } from "@mui/material";
+import { DataGrid, GridCellParams, GridColDef } from "@mui/x-data-grid";
+import { amber, purple } from "@mui/material/colors";
 
 function TransactionHistory() {
   const columns: GridColDef[] = [
-    { field: "time", headerName: "거래시각", width: 220 },
-    { field: "item", headerName: "종목", width: 220 },
-    { field: "position", headerName: "포지션", width: 220 },
-    { field: "price", headerName: "매수/매도가", width: 220 },
-    { field: "amount", headerName: "매수/매도수량", width: 220 },
-    { field: "totalPrice", headerName: "총매수/매도금액", width: 220 },
-    { field: "profitRatio", headerName: "손익률", width: 220 },
-    { field: "realizedProfit", headerName: "실현손익", width: 220 },
+    { field: "time", headerName: "거래시각", width: 170 },
+    {
+      field: "item",
+      headerName: "종목",
+      width: 150,
+      headerAlign: "center",
+      align: "center",
+    },
+    {
+      field: "position",
+      headerName: "포지션",
+      width: 150,
+      headerAlign: "center",
+      align: "center",
+      renderCell: (params: GridCellParams) => (
+        <Chip
+          label={params.value}
+          sx={{
+            userSelect: "none",
+            fontWeight: 500,
+            backgroundColor: params.value === "BUY" ? purple[100] : amber[200],
+            color: "white",
+            borderRadius: 2,
+          }}
+        />
+      ),
+    },
+    {
+      field: "price",
+      headerName: "매수/매도가",
+      width: 220,
+      headerAlign: "center",
+      align: "center",
+      renderCell: (params: GridCellParams) => (
+        <Typography variant="body2" component="span">
+          {params.value.toLocaleString() + " KRW"}
+        </Typography>
+      ),
+    },
+    {
+      field: "amount",
+      headerName: "매수/매도수량",
+      width: 150,
+      headerAlign: "center",
+      align: "center",
+    },
+    {
+      field: "totalPrice",
+      headerName: "총매수/매도금액",
+      width: 220,
+      headerAlign: "center",
+      align: "center",
+      renderCell: (params: GridCellParams) => (
+        <Typography variant="body2" component="span">
+          {params.value.toLocaleString() + " KRW"}
+        </Typography>
+      ),
+    },
+    {
+      field: "profitRatio",
+      headerName: "손익률",
+      width: 220,
+      headerAlign: "center",
+      align: "center",
+      renderCell: (params: GridCellParams) => (
+        <Typography
+          variant="body2"
+          component="span"
+          color={params.value.slice(0, 1) === "-" ? "blue" : "red"}
+        >
+          {params.value}
+        </Typography>
+      ),
+    },
+    {
+      field: "realizedProfit",
+      headerName: "실현손익",
+      width: 220,
+      headerAlign: "center",
+      align: "center",
+      renderCell: (params: GridCellParams) => (
+        <Typography variant="body2" component="span">
+          {params.value.toLocaleString() + " KRW"}
+        </Typography>
+      ),
+    },
   ];
 
   const rows = [
@@ -34,7 +113,7 @@ function TransactionHistory() {
       price: 30122334,
       amount: 0.1,
       totalPrice: 3012233,
-      profitRatio: "+0.1%",
+      profitRatio: "-0.1%",
       realizedProfit: 2122,
     },
   ];

--- a/src/components/oasisbot/TransactionHistory.tsx
+++ b/src/components/oasisbot/TransactionHistory.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import { Box, Chip, Typography } from "@mui/material";
-import { DataGrid, GridCellParams, GridColDef } from "@mui/x-data-grid";
+import {
+  DataGrid,
+  GridCellParams,
+  GridColDef,
+  GridValueFormatterParams,
+} from "@mui/x-data-grid";
 import { amber, purple } from "@mui/material/colors";
 
 function TransactionHistory() {
@@ -38,9 +43,11 @@ function TransactionHistory() {
       width: 220,
       headerAlign: "center",
       align: "center",
+      valueFormatter: (params: GridValueFormatterParams<number>) =>
+        params.value ? `${params.value.toLocaleString()} KRW` : "-",
       renderCell: (params: GridCellParams) => (
         <Typography variant="body2" component="span">
-          {params.value.toLocaleString() + " KRW"}
+          {params.formattedValue}
         </Typography>
       ),
     },
@@ -57,9 +64,11 @@ function TransactionHistory() {
       width: 220,
       headerAlign: "center",
       align: "center",
+      valueFormatter: (params: GridValueFormatterParams<number>) =>
+        params.value ? `${params.value.toLocaleString()} KRW` : "-",
       renderCell: (params: GridCellParams) => (
         <Typography variant="body2" component="span">
-          {params.value.toLocaleString() + " KRW"}
+          {params.formattedValue}
         </Typography>
       ),
     },
@@ -85,9 +94,11 @@ function TransactionHistory() {
       width: 220,
       headerAlign: "center",
       align: "center",
+      valueFormatter: (params: GridValueFormatterParams<number>) =>
+        params.value ? `${params.value.toLocaleString()} KRW` : "-",
       renderCell: (params: GridCellParams) => (
         <Typography variant="body2" component="span">
-          {params.value.toLocaleString() + " KRW"}
+          {params.formattedValue}
         </Typography>
       ),
     },

--- a/src/components/oasisbot/TransactionHistory.tsx
+++ b/src/components/oasisbot/TransactionHistory.tsx
@@ -12,18 +12,18 @@ import {
 
 function TransactionHistory() {
   const columns: GridColDef[] = [
-    { field: "time", headerName: "거래시각", width: 170 },
+    { field: "time", headerName: "거래시각", flex: 1 },
     {
       field: "item",
       headerName: "종목",
-      width: 150,
+      flex: 1,
       headerAlign: "center",
       align: "center",
     },
     {
       field: "position",
       headerName: "포지션",
-      width: 150,
+      flex: 1,
       headerAlign: "center",
       align: "center",
       renderCell: (
@@ -44,7 +44,7 @@ function TransactionHistory() {
     {
       field: "price",
       headerName: "매수/매도가",
-      width: 220,
+      flex: 1,
       headerAlign: "center",
       align: "center",
       valueFormatter: (params: GridValueFormatterParams<number>) =>
@@ -60,14 +60,14 @@ function TransactionHistory() {
     {
       field: "amount",
       headerName: "매수/매도수량",
-      width: 150,
+      flex: 1,
       headerAlign: "center",
       align: "center",
     },
     {
       field: "totalPrice",
       headerName: "총매수/매도금액",
-      width: 220,
+      flex: 1,
       headerAlign: "center",
       align: "center",
       valueFormatter: (params: GridValueFormatterParams<number>) =>
@@ -83,7 +83,7 @@ function TransactionHistory() {
     {
       field: "profitRatio",
       headerName: "손익률",
-      width: 220,
+      flex: 1,
       headerAlign: "center",
       align: "center",
       valueFormatter: (params: GridValueFormatterParams<string>) => {
@@ -107,7 +107,7 @@ function TransactionHistory() {
     {
       field: "realizedProfit",
       headerName: "실현손익",
-      width: 220,
+      flex: 1,
       headerAlign: "center",
       align: "center",
       valueFormatter: (params: GridValueFormatterParams<number>) =>
@@ -137,7 +137,7 @@ function TransactionHistory() {
     {
       id: 2,
       time: "22-06-23 22:09:11",
-      item: "비트코인",
+      item: "스테이터스네트워크토큰",
       position: "SELL",
       price: 30122334,
       amount: 0.1,


### PR DESCRIPTION
- Figma 디자인에 맞춰 컬럼별 정렬
- 포지션 컬럼 MUI Chip 컴포넌트 적용
- 매수/매도가, 총매수/매도금액, 실현손익 컬럼 숫자 천단위 끊기 및 원화 표기 추가
- 손익률 색깔 추가

※ 각 컬럼값을 백엔드에서 어떻게 넘겨줄지 몰라서 그냥 임의로 더미 데이터 만들어서 거기에 맞춰서 포매팅 및 스타일링 했습니다.