### PR TITLE
FEAT: Preset page 초안

### DIFF
--- a/src/cards/OasisBotListCard/index.tsx
+++ b/src/cards/OasisBotListCard/index.tsx
@@ -7,7 +7,7 @@ import useMarketSelect from "@/hooks/common/useMarketSelect";
 import usePriceStatusSelect from "@/hooks/common/usePriceStatusSelect";
 import usePresets from "@/hooks/dashboard/usePresets";
 
-function PresetsCard() {
+export default function OasisBotListCard() {
   const { columns, presetRows, isPresetsLoading } = usePresets();
   const { PriceStatusSelect } = usePriceStatusSelect();
   const { CurrencySelect } = useCurrencySelect();
@@ -50,5 +50,3 @@ function PresetsCard() {
     </Card>
   );
 }
-
-export default PresetsCard;

--- a/src/cards/OasisBotRunCard/index.tsx
+++ b/src/cards/OasisBotRunCard/index.tsx
@@ -7,7 +7,7 @@ import OasisBotButton from "@/components/oasisbot/OasisBotButton";
 import OasisBotMarketSelect from "@/components/oasisbot/OasisBotMarketSelect";
 import OasisBotSelect from "@/components/oasisbot/OasisBotSelect";
 
-function RunOasisBotCard() {
+function OasisBotRunCard() {
   const [selectedMarket, setSelectedMarket] = useState<string>("");
   const [selectedPreset, setSelectedPreset] = useState<string>("");
   const [selectedTradeItem, setSelectedTradeItem] = useState<string>("");
@@ -86,4 +86,4 @@ function RunOasisBotCard() {
   );
 }
 
-export default RunOasisBotCard;
+export default OasisBotRunCard;

--- a/src/cards/PresetIndicatorInfoCard/index.tsx
+++ b/src/cards/PresetIndicatorInfoCard/index.tsx
@@ -1,0 +1,5 @@
+import Card from "@/cards/Card";
+
+export default function PresetIndicatorInfoCard() {
+  return <Card>indicator info</Card>;
+}

--- a/src/cards/PresetInfoCard/index.tsx
+++ b/src/cards/PresetInfoCard/index.tsx
@@ -1,0 +1,5 @@
+import Card from "@/cards/Card";
+
+export default function PresetInfoCard() {
+  return <Card>preset info</Card>;
+}

--- a/src/cards/PresetSettingCard/index.tsx
+++ b/src/cards/PresetSettingCard/index.tsx
@@ -1,0 +1,5 @@
+import Card from "@/cards/Card";
+
+export default function PresetSettingCard() {
+  return <Card>preset setting</Card>;
+}

--- a/src/cards/PresetWeightInfoCard/index.tsx
+++ b/src/cards/PresetWeightInfoCard/index.tsx
@@ -1,0 +1,5 @@
+import Card from "@/cards/Card";
+
+export default function PresetWeightInfoCard() {
+  return <Card>preset weight info</Card>;
+}

--- a/src/cards/PresetWeightSettingCard/index.tsx
+++ b/src/cards/PresetWeightSettingCard/index.tsx
@@ -1,0 +1,5 @@
+import Card from "@/cards/Card";
+
+export default function PresetWeightSettingCard() {
+  return <Card>preset weight setting</Card>;
+}

--- a/src/components/Layout/Carousel/index.tsx
+++ b/src/components/Layout/Carousel/index.tsx
@@ -31,7 +31,7 @@ export default function Carousel({ children, minWidth }: CarouselProps) {
         )}
         <Box
           ref={childRef}
-          className="absolute w-full transition-all duration-500"
+          className="absolute w-full transition-all duration-500 pb-4"
           sx={{
             left: align === "left" ? "0" : `calc(-100% + ${size.width}px)`,
           }}

--- a/src/components/Layout/Carousel/index.tsx
+++ b/src/components/Layout/Carousel/index.tsx
@@ -17,7 +17,7 @@ export default function Carousel({ children, minWidth }: CarouselProps) {
   return (
     <Box
       ref={componentRef}
-      className="w-full"
+      className="relative w-full"
       sx={{ height: `${childSize.height}px` }}
     >
       <Box className="absolute w-full" sx={{ minWidth: `${minWidth}px` }}>

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -33,7 +33,9 @@ export default function Layout({ children }: { children: React.ReactNode }) {
                 : "ml-[80px] transition-all duration-300"
             }
           >
-            <Box className="w-full min-h-screen p-4 pl-8">{children}</Box>
+            <Box className="w-full h-[calc(100vh-70px)] p-4 pl-8">
+              {children}
+            </Box>
           </Box>
         </Stack>
       </Stack>

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -4,7 +4,7 @@ import AssetStatusCard from "@/cards/AssetStatusCard/index";
 import BotTransactionCard from "@/cards/BotTransactionCard";
 import ChartCard from "@/cards/ChartCard";
 import CircleChartCard from "@/cards/CircleChartCard/index";
-import PresetsCard from "@/cards/PresetsCard";
+import OasisBotListCard from "@/cards/OasisBotListCard";
 import ProfitRankCard from "@/cards/ProfitRankCard";
 import Layout from "@/components/Layout";
 import Carousel from "@/components/Layout/Carousel/index";
@@ -24,7 +24,7 @@ export default function Home() {
               <ChartCard />
             </Box>
             <Box className="w-5/12">
-              <PresetsCard />
+              <OasisBotListCard />
             </Box>
           </Stack>
           <Stack direction="row" className="gap-4 h-[436px]">

--- a/src/pages/oasisbot/index.tsx
+++ b/src/pages/oasisbot/index.tsx
@@ -1,8 +1,8 @@
 import { Box, Stack } from "@mui/material";
 import BotListCard from "@/cards/BotListCard";
 import OasisBotListCard from "@/cards/OasisBotListCard/index";
+import OasisBotRunCard from "@/cards/OasisBotRunCard";
 import RealtimeTransactionCard from "@/cards/RealtimeTransactionCard";
-import RunOasisBotCard from "@/cards/RunOasisBotCard";
 import Carousel from "@/components/Layout/Carousel";
 import Layout from "@/components/Layout/index";
 
@@ -14,7 +14,7 @@ function OasisBot() {
           <Stack className="w-4/6 gap-4">
             <Stack direction="row" className="gap-4 h-[495px]">
               <Box className="w-2/5">
-                <RunOasisBotCard />
+                <OasisBotRunCard />
               </Box>
               <Box className="w-3/5 gap-4 h-[495px]">
                 <OasisBotListCard />

--- a/src/pages/oasisbot/index.tsx
+++ b/src/pages/oasisbot/index.tsx
@@ -1,8 +1,8 @@
 import { Box, Stack } from "@mui/material";
 import BotListCard from "@/cards/BotListCard";
+import OasisBotListCard from "@/cards/OasisBotListCard/index";
 import RealtimeTransactionCard from "@/cards/RealtimeTransactionCard";
 import RunOasisBotCard from "@/cards/RunOasisBotCard";
-import TempCard from "@/cards/TempCard";
 import Carousel from "@/components/Layout/Carousel";
 import Layout from "@/components/Layout/index";
 
@@ -17,7 +17,7 @@ function OasisBot() {
                 <RunOasisBotCard />
               </Box>
               <Box className="w-3/5 gap-4 h-[495px]">
-                <TempCard />
+                <OasisBotListCard />
               </Box>
             </Stack>
             <Stack direction="row" className="gap-4 h-[400px]">

--- a/src/pages/oasislab/index.tsx
+++ b/src/pages/oasislab/index.tsx
@@ -1,6 +1,6 @@
 import { Box, Stack } from "@mui/material";
 import BotListCard from "@/cards/BotListCard/index";
-import RunOasisBotCard from "@/cards/RunOasisBotCard";
+import RunOasisBotCard from "@/cards/OasisBotRunCard";
 import TestInfoCard from "@/cards/TestInfoCard/index";
 import TestResultChartCard from "@/cards/TestResultChartCard/index";
 import TestResultInfoCard from "@/cards/TestResultInfoCard/index";

--- a/src/pages/preset/index.tsx
+++ b/src/pages/preset/index.tsx
@@ -1,7 +1,42 @@
+import { Box, Stack } from "@mui/material";
+import PresetIndicatorInfoCard from "@/cards/PresetIndicatorInfoCard/index";
+import PresetInfoCard from "@/cards/PresetInfoCard/index";
+import PresetSettingCard from "@/cards/PresetSettingCard/index";
+import PresetWeightInfoCard from "@/cards/PresetWeightInfoCard/index";
+import PresetWeightSettingCard from "@/cards/PresetWeightSettingCard/index";
+import Carousel from "@/components/Layout/Carousel/index";
 import Layout from "@/components/Layout/index";
 
 function OasisBot() {
-  return <Layout>Preset</Layout>;
+  return (
+    <Layout>
+      <Carousel minWidth={1600}>
+        <Stack direction="row" className="w-full h-[900px] gap-4">
+          <Box className="w-1/4 h-full">
+            <PresetInfoCard />
+          </Box>
+          <Stack className="w-3/4 h-full gap-4">
+            <Stack direction="row" className="w-full h-1/2 min-h-[436px] gap-4">
+              <Box className="w-1/3 h-full">
+                <PresetSettingCard />
+              </Box>
+              <Box className="w-2/3 h-full">
+                <PresetIndicatorInfoCard />
+              </Box>
+            </Stack>
+            <Stack direction="row" className="w-full h-1/2 min-h-[436px] gap-4">
+              <Box className="w-3/4 h-full">
+                <PresetWeightSettingCard />
+              </Box>
+              <Box className="w-1/4 h-full">
+                <PresetWeightInfoCard />
+              </Box>
+            </Stack>
+          </Stack>
+        </Stack>
+      </Carousel>
+    </Layout>
+  );
 }
 
 export default OasisBot;


### PR DESCRIPTION
프리셋 페이지 구도를 잡고 카드를 생성했습니다.
생성된 카드는 총 5개이고, 피그마의 각자 진행할 카드를 마크해두었습니다