### PR TITLE
FEAT: 실행중인 봇 선택시 실행카드 상세조회 기능

### DIFF
--- a/src/cards/CardButton.tsx
+++ b/src/cards/CardButton.tsx
@@ -5,17 +5,20 @@ interface CardButtonProps {
   text: string;
   className?: string;
   onClick?: () => void;
+  disabled?: boolean;
 }
 
 function CardButton({
   text,
   className = "text-white bg-brand",
   onClick,
+  disabled,
 }: CardButtonProps) {
   return (
     <Button
       className={`w-full flex mx-4 my-3 p-3 rounded-none ${className}`}
       onClick={onClick}
+      disabled={disabled}
     >
       <Typography
         sx={{

--- a/src/cards/oasisbot/OasisBotListCard/index.tsx
+++ b/src/cards/oasisbot/OasisBotListCard/index.tsx
@@ -1,10 +1,13 @@
+import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { CardContent, Chip } from "@mui/material";
-import { DataGrid } from "@mui/x-data-grid";
+import { DataGrid, GridRowSelectionModel } from "@mui/x-data-grid";
+import { useSetAtom } from "jotai";
 import Card from "@/cards/Card";
 import CardFooter from "@/cards/CardFooter";
 import CardHeader from "@/cards/CardHeader";
 import OasisBotListColumns from "@/components/table/OasisBotListColumns";
+import { botAtom } from "@/datas/oasisbotTransaction";
 import { useBotQuery } from "@/hooks/query/useOasisBot";
 
 interface Props {
@@ -15,6 +18,32 @@ export default function OasisBotListCard({ nav }: Props) {
   const {
     botQuery: { data, isLoading },
   } = useBotQuery();
+  const [selectedRow, setSelectedRow] = useState<GridRowSelectionModel>([]);
+  const setSelectedBot = useSetAtom(botAtom);
+
+  useEffect(() => {
+    if (selectedRow.length > 0) {
+      setSelectedBot(
+        data?.find(value => value.id === selectedRow[0]) || {
+          id: -1,
+          isRunning: false,
+          presetName: "",
+          startBalance: 0,
+          runningTime: 0,
+          coinType: "",
+        },
+      );
+    } else {
+      setSelectedBot({
+        id: -1,
+        isRunning: false,
+        presetName: "",
+        startBalance: 0,
+        runningTime: 0,
+        coinType: "",
+      });
+    }
+  }, [selectedRow]);
 
   const router = useRouter();
   return (
@@ -27,6 +56,10 @@ export default function OasisBotListCard({ nav }: Props) {
           columns={columns}
           rows={data ?? []}
           loading={isLoading}
+          onRowSelectionModelChange={newRow => {
+            setSelectedRow(selectedRow[0] === newRow[0] ? [] : newRow);
+          }}
+          rowSelectionModel={selectedRow}
           hideFooter
           sx={{
             ".MuiDataGrid-overlayWrapper": { height: "215px" },

--- a/src/cards/oasisbot/OasisBotSelectCard/index.tsx
+++ b/src/cards/oasisbot/OasisBotSelectCard/index.tsx
@@ -164,7 +164,7 @@ function OasisBotSelectCard() {
       </CardContent>
       <CardFooter className="bottom-2">
         <CardButton
-          text="삭제"
+          text="초기화"
           className={`mr-1 text-white ${selectedBot.isRunning ? "bg-neutral-400" : "bg-neutral-700"}`}
           onClick={onRemove}
           disabled={!!selectedBot.isRunning}

--- a/src/cards/oasisbot/OasisBotSelectCard/index.tsx
+++ b/src/cards/oasisbot/OasisBotSelectCard/index.tsx
@@ -1,0 +1,190 @@
+import { useEffect, useState } from "react";
+import Image from "next/image";
+import {
+  CardContent,
+  Chip,
+  InputAdornment,
+  InputBase,
+  InputLabel,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { useAtom, useAtomValue } from "jotai";
+import Card from "@/cards/Card";
+import CardButton from "@/cards/CardButton";
+import CardFooter from "@/cards/CardFooter";
+import CardHeader from "@/cards/CardHeader";
+import LeverageNoticeDialog from "@/cards/oasisbot/OasisBotRunCard/LeverageNoticeDialog";
+import InfoDialog from "@/components/common/InfoDialog";
+import FormTextField from "@/components/form/FormTextField";
+import exchangeAtom from "@/datas/exchange";
+import { botAtom } from "@/datas/oasisbotTransaction";
+import { useBot, useBotInfo } from "@/hooks/query/useOasisBot";
+import useModalGlobal from "@/hooks/useModalGlobal";
+import { exchangeToKorean } from "@/libs/string";
+
+function OasisBotSelectCard() {
+  const [startBalance, setStartBalance] = useState<number>(5000);
+  const [selectedPreset, setSelectedPreset] = useState<string>("");
+  const [selectedTradeItem, setSelectedTradeItem] = useState<string>("");
+  const [standardMinute, setStandardMinute] = useState<string>("");
+
+  const [exchange] = useAtom(exchangeAtom);
+  const selectedBot = useAtomValue(botAtom);
+
+  useEffect(() => {
+    setStartBalance(selectedBot.startBalance);
+    setSelectedPreset(selectedBot.presetName);
+    setSelectedTradeItem(selectedBot.coinType);
+    // setStandardMinute(selectedBot.standardMinute);
+  }, [selectedBot]);
+
+  const { stopBotMutation, restartBotMutation } = useBot();
+  const { openModal, closeModal } = useModalGlobal();
+  const { balanceQuery } = useBotInfo();
+
+  const onRemove = () => {
+    console.log("onRemove");
+  };
+
+  const stopBot = () => {
+    // openModal(
+    //   <InfoDialog
+    //     title="봇 중지"
+    //     description={[
+    //       "매수된 종목이 있을 시, 자동 매도가 안되어 잔고에 영향을 초래할 수 있습니다.",
+    //     ]}
+    //     handleClose={closeModal}
+    //   />,
+    // );
+
+    stopBotMutation.mutate(selectedBot.id);
+  };
+
+  const restartBot = () => {
+    restartBotMutation.mutate(selectedBot.id);
+  };
+
+  return (
+    <Card>
+      <CardHeader
+        id="bot-start"
+        title="오아시스 BOT 실행"
+        subtitle={`주문가능 금액\n${exchange === "upbit" ? "￦" : "$"}${balanceQuery.data?.availableBalance?.toLocaleString() ?? 0}`}
+        action={
+          <Chip
+            label={exchangeToKorean(exchange)}
+            variant="outlined"
+            className="text-brand"
+          />
+        }
+      />
+      <CardContent>
+        <Stack className="gap-2">
+          <FormTextField
+            id="transactionAmount"
+            label={`거래금액을 입력해 주세요 (최소 ${exchange === "upbit" ? "₩5,000" : "$100"})`}
+            type="number"
+            value={startBalance}
+            setValue={setStartBalance}
+            startAdornment={
+              <InputAdornment position="start">
+                {exchange === "upbit" ? "￦" : "$"}
+              </InputAdornment>
+            }
+            inputLabelProps={{
+              className: "text-brand opacity-100",
+            }}
+            inputProps={{
+              className: "cursor-not-allowed",
+            }}
+            readOnly
+          />
+          <FormTextField
+            id="presets"
+            label="설정 프리셋"
+            placeholder="설정 프리셋을 선택"
+            value={selectedPreset}
+            readOnly
+            inputProps={{
+              className: "cursor-not-allowed",
+            }}
+          />
+          <FormTextField
+            id="tradeItem"
+            label="매매종목"
+            placeholder="매매종목을 선택"
+            value={selectedTradeItem}
+            readOnly
+            inputProps={{
+              className: "cursor-not-allowed",
+            }}
+          />
+          <FormTextField
+            id="tradeItem"
+            label="기준 분봉"
+            placeholder="분봉 선택"
+            value={standardMinute}
+            readOnly
+            inputProps={{
+              className: "cursor-not-allowed",
+            }}
+          />
+          <Stack className="w-full">
+            <InputLabel htmlFor="leverage">
+              <Image
+                src="/icons/control/info.png"
+                alt="info"
+                width={12}
+                height={12}
+                className="mr-1"
+              />
+              <Typography
+                variant="100R"
+                className="text-neutral-600 underline hover:cursor-pointer"
+                onClick={() =>
+                  openModal(<LeverageNoticeDialog handleClose={closeModal} />)
+                }
+              >
+                현재 설정 레버리지
+              </Typography>
+            </InputLabel>
+            <InputBase
+              placeholder={`${exchange === "upbit" ? "업비트 거래소는 레버리지 설정 불가" : "레버리지 고정값"}`}
+              fullWidth
+              classes={{
+                input:
+                  "h-[30px] p-0 flex-0 items-center justify-center leading-[16px] text-[14px] border-solid border-b-[1px] border-x-0 border-t-0 border-neutral-300 font-[500] text-font-2",
+                disabled: "cursor-not-allowed bg-neutral-200 text-neutral-600",
+              }}
+              disabled
+            />
+          </Stack>
+        </Stack>
+      </CardContent>
+      <CardFooter className="bottom-2">
+        <CardButton
+          text="삭제"
+          className={`mr-1 text-white ${selectedBot.isRunning ? "bg-neutral-400" : "bg-neutral-700"}`}
+          onClick={onRemove}
+          disabled={!!selectedBot.isRunning}
+        />
+        {selectedBot.isRunning ? (
+          <CardButton
+            text="중지"
+            className="ml-1 text-white bg-[#F46565]"
+            onClick={stopBot}
+          />
+        ) : (
+          <CardButton
+            text="재실행"
+            className="ml-1 text-white bg-brand"
+            onClick={restartBot}
+          />
+        )}
+      </CardFooter>
+    </Card>
+  );
+}
+
+export default OasisBotSelectCard;

--- a/src/components/table/timeConvert.ts
+++ b/src/components/table/timeConvert.ts
@@ -13,5 +13,6 @@ export default function TimeConvert(time: number) {
     }
     return `${m}분 ${s}초`;
   }
-  return `${h}시간 ${m}분 ${s}초`;
+  return `${h}시간 ${m}분`;
+  // return `${h}시간 ${m}분 ${s}초`;
 }

--- a/src/datas/oasisbotTransaction.ts
+++ b/src/datas/oasisbotTransaction.ts
@@ -1,3 +1,6 @@
+import { atom } from "jotai";
+import { BotType } from "@/apis/oasisbot/bot";
+
 interface BotTransaction {
   id: number;
   market: string;
@@ -24,9 +27,20 @@ interface BotTransactionPrice {
   presetName: string;
 }
 
+const botAtom = atom<BotType>({
+  id: -1,
+  isRunning: false,
+  presetName: "",
+  startBalance: 0,
+  runningTime: 0,
+  coinType: "",
+});
+
 export type {
   BotTransaction,
   BotTransactionProfit,
   BotTransactionQuantity,
   BotTransactionPrice,
 };
+
+export { botAtom };

--- a/src/pages/oasisbot/index.tsx
+++ b/src/pages/oasisbot/index.tsx
@@ -1,12 +1,17 @@
 import { Box, Stack } from "@mui/material";
+import { useAtomValue } from "jotai";
 import OasisBotListCard from "@/cards/oasisbot/OasisBotListCard";
 import OasisBotRunCard from "@/cards/oasisbot/OasisBotRunCard";
+import OasisBotSelectCard from "@/cards/oasisbot/OasisBotSelectCard";
 import OasisBotTotalCardList from "@/cards/oasisbot/OasisBotTotalCard/list";
 import OasisBotTransactionCard from "@/cards/oasisbot/OasisBotTransactionCard";
+import { botAtom } from "@/datas/oasisbotTransaction";
 import Carousel from "@/layouts/Carousel";
 import Layout from "@/layouts/Layout";
 
 function OasisBot() {
+  const bot = useAtomValue(botAtom);
+
   return (
     <Layout>
       <Carousel minWidth={1600}>
@@ -14,7 +19,7 @@ function OasisBot() {
           <Stack className="w-4/6 gap-4">
             <Stack direction="row" className="gap-4 h-[495px]">
               <Box className="w-2/5">
-                <OasisBotRunCard />
+                {bot.id === -1 ? <OasisBotRunCard /> : <OasisBotSelectCard />}
               </Box>
               <Box className="w-3/5 gap-4 h-[495px]">
                 <OasisBotListCard nav="oasisbot" />


### PR DESCRIPTION
**작업 내용**
- 실행중인 봇 목록에서 특정 행 선택 -> 오아시스 Bot 실행 카드 상세 조회 처리
- 실행중인 봇 목록 운영기간 컬럼값 큰단위 2개만 조회되도록 처리

**논의할 것들**
- [ ] 봇 중지/재실행시 모달
- [ ] 봇 선택 해제
- [x] 삭제 버튼에 대한 API 미존재
    - 삭제 대신 "초기화"로 변경 
- [ ] 실행중인 Bot 목록 상태 컬럼 변경 처리
- [ ] 봇 목록 조회 API response에 기준 분봉값이 필요

**비고**
- 현재 "주문가능 금액"에 대한 API 조회값이 이상합니다. 확인 부탁드립니다. @Son-GyeongSik 
<img width="214" alt="image" src="https://github.com/user-attachments/assets/a7d8bcc3-5d2c-4bd2-856c-d1c1221377b2">

